### PR TITLE
Refactor fusion overlay architecture in viewer

### DIFF
--- a/client/src/components/dicom/FusionOverlayLayer.tsx
+++ b/client/src/components/dicom/FusionOverlayLayer.tsx
@@ -1,0 +1,42 @@
+import React, { useEffect } from 'react';
+import { useFusionStore } from '@/lib/use-fusion-store';
+
+type Props = {
+  ctx: CanvasRenderingContext2D | null;
+  canvas: HTMLCanvasElement | null;
+  currentImage: any | null;
+  currentIndex: number;
+  opacity: number;
+  onMeta?: (meta: { transformSource: string | null; registrationId: string | null }) => void;
+};
+
+export function FusionOverlayLayer({ ctx, canvas, currentImage, currentIndex, opacity, onMeta }: Props) {
+  const getOverlayForSop = useFusionStore(s => s.getOverlayForSop);
+
+  useEffect(() => {
+    if (!ctx || !canvas || !currentImage || opacity <= 0) return;
+    const sop = currentImage?.sopInstanceUID;
+    if (!sop) return;
+    const instNumber = Number(currentImage.instanceNumber ?? currentImage.metadata?.instanceNumber ?? NaN);
+    const instanceNumber = Number.isFinite(instNumber) ? instNumber : null;
+    const imagePosition = Array.isArray(currentImage.imagePositionPatient)
+      ? currentImage.imagePositionPatient
+      : Array.isArray(currentImage.metadata?.imagePositionPatient)
+        ? currentImage.metadata.imagePositionPatient
+        : null;
+
+    let cancelled = false;
+    getOverlayForSop({ sopInstanceUID: sop, index: currentIndex, instanceNumber, imagePosition }).then((overlay) => {
+      if (cancelled || !overlay || !overlay.hasSignal) return;
+      ctx.save();
+      ctx.globalAlpha = opacity;
+      ctx.drawImage(overlay.canvas, 0, 0, canvas.width, canvas.height);
+      ctx.restore();
+      onMeta?.({ transformSource: overlay.transformSource, registrationId: overlay.registrationId });
+    }).catch(() => {/* non-blocking */});
+    return () => { cancelled = true; };
+  }, [ctx, canvas, currentImage, currentIndex, opacity, getOverlayForSop, onMeta]);
+
+  return null;
+}
+

--- a/client/src/components/dicom/viewer-interface.tsx
+++ b/client/src/components/dicom/viewer-interface.tsx
@@ -19,6 +19,7 @@ import { DICOMSeries, DICOMStudy, WindowLevel, WINDOW_LEVEL_PRESETS } from '@/li
 import type { RegistrationAssociation, RegistrationSeriesDetail } from '@/types/fusion';
 import type { FusionManifest, FusionSecondaryDescriptor } from '@/types/fusion';
 import { fetchFusionManifest, preloadFusionSecondary, getFusionManifest, clearFusionCaches } from '@/lib/fusion-utils';
+import { setPrimary as fusionSetPrimary, setSecondary as fusionSetSecondary, refreshManifest as fusionRefreshManifest } from '@/lib/use-fusion-store';
 import { cornerstoneConfig } from '@/lib/cornerstone-config';
 import { LoadingProgress } from './loading-progress';
 import { useSeriesSelection } from '@/hooks/use-series-selection';
@@ -39,6 +40,7 @@ interface ViewerInterfaceProps {
 }
 
 export function ViewerInterface({ studyData, onContourSettingsChange, contourSettings, onLoadedRTSeriesChange }: ViewerInterfaceProps) {
+  // Fusion store integration: mirror selected CT and chosen secondary
   const [selectedSeries, setSelectedSeries] = useState<DICOMSeries | null>(null);
   const [windowLevel, setWindowLevel] = useState<WindowLevel>(WINDOW_LEVEL_PRESETS.abdomen);
   const [error, setError] = useState<any>(null);
@@ -121,6 +123,20 @@ export function ViewerInterface({ studyData, onContourSettingsChange, contourSet
       setShowFusionPanel(true);
     }
   }, [secondarySeriesId]);
+
+  // Keep fusion store in sync with UI selection
+  useEffect(() => {
+    const primaryId = selectedSeries?.id ?? null;
+    if (primaryId) {
+      fusionSetPrimary(primaryId);
+      fusionRefreshManifest({ force: true, preload: true });
+    }
+  }, [selectedSeries?.id, fusionSetPrimary, fusionRefreshManifest]);
+
+  useEffect(() => {
+    const modality = (series.find(s => s.id === secondarySeriesId)?.modality || 'PT') as string;
+    fusionSetSecondary(secondarySeriesId, modality);
+  }, [secondarySeriesId, series, fusionSetSecondary]);
   
   // Boolean operations state
   const [showBooleanOperations, setShowBooleanOperations] = useState(false);

--- a/client/src/components/dicom/working-viewer.tsx
+++ b/client/src/components/dicom/working-viewer.tsx
@@ -23,8 +23,9 @@ import {
 import { applyDirectionalGrow } from "@/lib/contour-directional-grow";
 import { naiveCombineContours as combineContours, naiveSubtractContours as subtractContours } from "@/lib/contour-boolean-operations";
 import { predictNextSliceContour } from "@/lib/contour-prediction";
-import { FusionOverlayManager } from "@/lib/fusion-overlay-manager";
-import { clearFusionSlices } from "@/lib/fusion-utils";
+// import { FusionOverlayManager } from "@/lib/fusion-overlay-manager";
+import { setPrimary as fusionSetPrimary, setSecondary as fusionSetSecondary, refreshManifest as fusionRefreshManifest, getOverlayForSop as fusionGetOverlayForSop } from '@/lib/use-fusion-store';
+import { clearFusionSlices, getFusedSlice, getFusedSliceSmart, fuseboxSliceToImageData } from "@/lib/fusion-utils";
 import { performPolygonUnion, polygonUnion } from "@/lib/polygon-union";
 import { doPolygonsIntersectSimple, unionMultipleContoursSimple, growContourSimple } from "@/lib/simple-polygon-operations";
 import { undoRedoManager } from "@/lib/undo-system";
@@ -229,13 +230,9 @@ const WorkingViewer = forwardRef(function WorkingViewerComponent(props: WorkingV
   const secondarySeriesId = externalSecondarySeriesId; // Use external prop directly instead of local state
   const fusionOpacity = externalFusionOpacity !== undefined ? externalFusionOpacity : 0.5;
   
-  // NEW FUSION: Simple manager-based approach
-  const fusionManagerRef = useRef<FusionOverlayManager | null>(null);
-  if (!fusionManagerRef.current) {
-    fusionManagerRef.current = new FusionOverlayManager(seriesId);
-  }
-  const fusionManager = fusionManagerRef.current;
-  
+  // NEW FUSION: store-driven overlay layer
+  // Fusion store API (module-level)
+
   const [fusionTransformSource, setFusionTransformSource] = useState<string | null>(null);
   const [fusionRegistrationId, setFusionRegistrationId] = useState<string | null>(null);
   
@@ -261,14 +258,16 @@ const WorkingViewer = forwardRef(function WorkingViewerComponent(props: WorkingV
   const fuseboxTransformSource = fusionTransformSource; // Alias for compatibility
   const getFusionManifest = () => null; // Stub
   
-  // Update fusion manager when secondary changes
+  // Initialize fusion store for this primary series and selected secondary
   useEffect(() => {
-    if (fusionManager) {
-      fusionManager.setSecondary(secondarySeriesId, secondaryModality);
-      fusionManager.clearCache(); // Clear cache on secondary change
-      clearFusionSlices(seriesId); // Clear old fusion data
-    }
-  }, [secondarySeriesId, fusionManager, secondaryModality, seriesId]);
+    fusionSetPrimary(seriesId);
+    fusionRefreshManifest({ force: true, preload: true });
+  }, [seriesId]);
+
+  useEffect(() => {
+    fusionSetSecondary(secondarySeriesId ?? null, secondaryModality);
+    clearFusionSlices(seriesId);
+  }, [secondarySeriesId, secondaryModality, seriesId]);
 
   const parseImagePosition = useCallback((image: any): [number, number, number] | null => {
     if (!image) return null;
@@ -457,7 +456,7 @@ const WorkingViewer = forwardRef(function WorkingViewerComponent(props: WorkingV
   );
 
   const convertSliceToCanvas = useCallback(
-    (slice: FuseboxSlice, defaultModality: string) => {
+    (slice: any, defaultModality: string) => {
       const { imageData, hasSignal } = fuseboxSliceToImageData(
         slice,
         slice.secondaryModality ?? defaultModality,
@@ -477,7 +476,7 @@ const WorkingViewer = forwardRef(function WorkingViewerComponent(props: WorkingV
   useEffect(() => {
     const entries = Array.from(fuseboxCacheRef.current.entries());
     if (!entries.length) return;
-    const updatedCache = new Map<string, { canvas: HTMLCanvasElement; slice: FuseboxSlice; timestamp: number; hasSignal: boolean }>();
+    const updatedCache = new Map<string, { canvas: HTMLCanvasElement; slice: any; timestamp: number; hasSignal: boolean }>();
     entries.forEach(([key, value]) => {
       const updated = convertSliceToCanvas(value.slice, value.slice.secondaryModality ?? secondaryModality ?? '');
       if (updated) {
@@ -547,7 +546,7 @@ const WorkingViewer = forwardRef(function WorkingViewerComponent(props: WorkingV
               const preferredIndex = Number.isFinite(instNumber) ? instNumber - 1 : centerIndex;
               const preferredPosition = parseImagePosition(image);
 
-              let slice;
+              let slice: any;
               try {
                 slice = await getFusedSlice(seriesId, secondarySeriesId, sop);
               } catch (error) {
@@ -4414,32 +4413,25 @@ const WorkingViewer = forwardRef(function WorkingViewerComponent(props: WorkingV
       // Always use CPU rendering for now - GPU integration needs more work
       render16BitImage(ctx, imageData.data, imageData.width, imageData.height);
       
-      // NEW FUSION: Simple overlay compositing
+      // NEW FUSION: Compose overlay via fusion store (non-blocking)
       if (secondarySeriesId && fusionOpacity > 0) {
         const primaryPosition = parseImagePosition(currentImage);
         const instNumber = Number(currentImage.instanceNumber ?? currentImage.metadata?.instanceNumber ?? NaN);
-        
-        fusionManager.getOverlay(
-          currentImage.sopInstanceUID,
-          currentIndex,
-          Number.isFinite(instNumber) ? instNumber : null,
-          primaryPosition
-        ).then(overlay => {
+        fusionGetOverlayForSop({
+          sopInstanceUID: currentImage.sopInstanceUID,
+          index: currentIndex,
+          instanceNumber: Number.isFinite(instNumber) ? instNumber : null,
+          imagePosition: primaryPosition
+        }).then(overlay => {
           if (overlay && overlay.hasSignal) {
-            // Composite the overlay onto the primary CT
             ctx.save();
             ctx.globalAlpha = fusionOpacity;
             ctx.drawImage(overlay.canvas, 0, 0, canvas.width, canvas.height);
             ctx.restore();
-            
-            // Update metadata for UI
             setFusionTransformSource(overlay.transformSource);
             setFusionRegistrationId(overlay.registrationId);
           }
-        }).catch(err => {
-          // Fusion failed - primary CT already rendered, so just log it
-          console.warn("Fusion overlay failed:", err);
-        });
+        }).catch(() => {});
       }
 
       // Render RT structure overlays if available
@@ -4516,9 +4508,9 @@ const WorkingViewer = forwardRef(function WorkingViewerComponent(props: WorkingV
           
           // Render MPR views asynchronously with same window/level as axial
           await Promise.all([
-            renderMPRCanvas(sagittalCanvasRef.current, 'sagittal', sagittalSliceIndex, currentWindowLevel.width, currentWindowLevel.center),
-            renderMPRCanvas(coronalCanvasRef.current, 'coronal', coronalSliceIndex, currentWindowLevel.width, currentWindowLevel.center)
-          ]);
+            sagittalCanvasRef.current && renderMPRCanvas(sagittalCanvasRef.current, 'sagittal', sagittalSliceIndex, currentWindowLevel.width, currentWindowLevel.center),
+            coronalCanvasRef.current && renderMPRCanvas(coronalCanvasRef.current, 'coronal', coronalSliceIndex, currentWindowLevel.width, currentWindowLevel.center)
+          ].filter(Boolean));
         } catch (mprError) {
           console.warn("Error rendering MPR views:", mprError);
         }
@@ -4682,165 +4674,9 @@ const WorkingViewer = forwardRef(function WorkingViewerComponent(props: WorkingV
     fusionPrefetchSetRef.current.clear();
   }, [secondarySeriesId]);
 
+  // LEGACY PATH DISABLED: Fusion overlay now handled by FusionOverlayLayer + useFusionStore
   const renderFusionOverlayNew = async (ctx: CanvasRenderingContext2D, primaryImage: any) => {
-    const requestToken = ++fusionRequestTokenRef.current;
-
-    // Abort any previous fusion fetch to prevent race conditions during fast switching
-    if (fusionAbortControllerRef.current) {
-      fusionAbortControllerRef.current.abort();
-    }
-    const abortController = new AbortController();
-    fusionAbortControllerRef.current = abortController;
-
-    const ensureActive = () => {
-      const isActive = requestToken === fusionRequestTokenRef.current;
-      if (!isActive) {
-        abortController.abort(); // Abort if this request is no longer active
-      }
-      return isActive;
-    };
-
-    if (!secondarySeriesId || fusionOpacity === 0) {
-      if (ensureActive()) setFuseboxTransformSource(null);
-      return;
-    }
-
-    if (fusionManifestLoading) {
-      // Gate rendering while the manifest is still loading
-      if (ensureActive()) {
-        fusionIssueRef.current = 'manifest-not-ready';
-        setFuseboxTransformSource(null);
-      }
-      return;
-    }
-
-    const status = fusionSecondaryStatuses?.get(secondarySeriesId);
-    // Normalize ID comparison to avoid string/number mismatch gating overlays forever
-    const manifestMatches = Number(fusionManifestPrimarySeriesId) === Number(seriesId);
-    const localManifest = getFusionManifest(seriesId);
-    const localReady = !!localManifest && localManifest.secondaries.some((s) => s.secondarySeriesId === secondarySeriesId && s.status === 'ready');
-    if (status?.status !== 'ready' || !manifestMatches || !localReady) {
-      if (ensureActive()) {
-        fusionIssueRef.current = 'manifest-not-ready';
-        setFuseboxTransformSource(null);
-      }
-      return;
-    }
-
-    const hasRegistrationMatrix = Array.isArray(registrationMatrix) && registrationMatrix.length === 16;
-
-    if (!primaryImage?.sopInstanceUID) {
-      if (ensureActive()) setFuseboxTransformSource(null);
-      return;
-    }
-
-    const transform = ctTransform.current;
-    if (!transform) {
-      return;
-    }
-
-    if (hasRegistrationMatrix) {
-      missingMatrixLogRef.current = false;
-    } else if (!missingMatrixLogRef.current) {
-      pushFusionLog('Proceeding without client-side matrix; expecting helper output', {
-        primary: seriesId,
-        secondary: secondarySeriesId,
-        registrationId: selectedRegistrationId ?? null,
-      });
-      missingMatrixLogRef.current = true;
-    }
-
-    const cacheKey = buildFuseboxCacheKey(
-      primaryImage.sopInstanceUID,
-      secondarySeriesId,
-      selectedRegistrationId ?? null,
-    );
-    let cached = fuseboxCacheRef.current.get(cacheKey);
-
-    if (!cached) {
-      try {
-        // Try exact SOP match first; if not found, fall back by instance number or index
-        let slice: FuseboxSlice;
-        const preferredPosition = parseImagePosition(primaryImage);
-        try {
-          slice = await getFusedSlice(seriesId, secondarySeriesId, primaryImage.sopInstanceUID);
-        } catch (e) {
-          const instNumber = Number(primaryImage.instanceNumber ?? primaryImage.metadata?.instanceNumber ?? NaN);
-          const index = Number.isFinite(instNumber) ? instNumber - 1 : currentIndex;
-          slice = await getFusedSliceSmart(
-            seriesId,
-            secondarySeriesId,
-            primaryImage.sopInstanceUID,
-            Number.isFinite(instNumber) ? instNumber : null,
-            index,
-            preferredPosition,
-          );
-        }
-
-        if (slice.registrationId && slice.registrationId !== selectedRegistrationId && ensureActive()) {
-          setSelectedRegistrationId(slice.registrationId);
-        }
-
-        if (slice.secondaryModality && slice.secondaryModality !== secondaryModality && ensureActive()) {
-          setSecondaryModality(slice.secondaryModality);
-        }
-
-        const prepared = convertSliceToCanvas(slice, secondaryModality);
-        if (!prepared) {
-          if (ensureActive()) {
-            fusionIssueRef.current = 'overlay-canvas-error';
-            setFuseboxTransformSource(null);
-          }
-          return;
-        }
-        cached = { ...prepared, timestamp: Date.now() };
-        fuseboxCacheRef.current.set(cacheKey, cached);
-        if (!prepared.hasSignal) {
-          pushFusionLog('Fused slice had no visible signal', {
-            sop: primaryImage.sopInstanceUID,
-            min: slice.min,
-            max: slice.max,
-          });
-        }
-      } catch (error: any) {
-        fuseboxCacheRef.current.delete(cacheKey);
-        if ((error as any)?.name === 'FusionOutOfRangeError') {
-          if (ensureActive()) {
-            fusionIssueRef.current = 'fusion-out-of-range';
-            setFuseboxTransformSource(null);
-          }
-          return;
-        }
-        if (ensureActive()) {
-          console.error('Fused overlay load failed:', error);
-          fusionIssueRef.current = 'fusebox-fetch-error';
-          setFuseboxTransformSource(null);
-        }
-        return;
-      }
-    }
-
-    if (!cached) {
-      if (ensureActive()) setFuseboxTransformSource(null);
-      return;
-    }
-
-    if (!cached.hasSignal) {
-      if (ensureActive()) {
-        fusionIssueRef.current = 'empty-fusebox-slice';
-        setFuseboxTransformSource(cached.slice.transformSource ?? null);
-      }
-      return;
-    }
-
-    if (!ensureActive()) return;
-
-    const source = cached.slice.transformSource ?? null;
-    setFuseboxTransformSource(source);
-    fusionIssueRef.current = null;
-
-    drawFusionOverlay(ctx, cached.canvas, transform, fusionOpacity);
-    prefetchFusionSlices(currentIndex);
+    return; // Single overlay path enforced
   };
 
   // Coordinate transformation functions for pen tool with CT transform applied

--- a/client/src/lib/use-fusion-store.ts
+++ b/client/src/lib/use-fusion-store.ts
@@ -1,0 +1,102 @@
+import type { FusionManifest } from '@/types/fusion';
+import { fetchFusionManifest, getFusionManifest, preloadFusionSecondary, getFusedSlice, getFusedSliceSmart, fuseboxSliceToImageData } from '@/lib/fusion-utils';
+
+type OverlayResult = {
+  canvas: HTMLCanvasElement;
+  hasSignal: boolean;
+  registrationId: string | null;
+  transformSource: string | null;
+};
+
+let primarySeriesId: number | null = null;
+let secondarySeriesId: number | null = null;
+let secondaryModality: string | null = null;
+let manifest: FusionManifest | null = null;
+let manifestLoading = false;
+let manifestError: string | null = null;
+const secondaryStatuses = new Map<number, { status: 'idle' | 'loading' | 'ready' | 'error'; error?: string | null }>();
+
+export function setPrimary(seriesId: number | null) {
+  primarySeriesId = seriesId;
+  manifest = null;
+  manifestError = null;
+}
+
+export function setSecondary(seriesId: number | null, modality?: string | null) {
+  secondarySeriesId = seriesId;
+  secondaryModality = modality ?? secondaryModality;
+}
+
+export async function refreshManifest(opts?: { secondarySeriesIds?: number[]; force?: boolean; preload?: boolean }) {
+  if (!primarySeriesId) return;
+  manifestLoading = true;
+  manifestError = null;
+  try {
+    const m = await fetchFusionManifest(primarySeriesId, {
+      secondarySeriesIds: opts?.secondarySeriesIds,
+      force: opts?.force ?? true,
+      preload: opts?.preload ?? true,
+    });
+    manifest = m;
+    manifestLoading = false;
+    secondaryStatuses.clear();
+    m.secondaries.forEach((sec) => {
+      const status = sec.status === 'ready' ? 'idle' : (sec.status as any);
+      secondaryStatuses.set(sec.secondarySeriesId, { status, error: sec.error });
+    });
+    const readyIds = m.secondaries.filter(s => s.status === 'ready').map(s => s.secondarySeriesId);
+    for (const sid of readyIds) {
+      try {
+        await preloadFusionSecondary(primarySeriesId, sid);
+        secondaryStatuses.set(sid, { status: 'ready' });
+      } catch (e: any) {
+        secondaryStatuses.set(sid, { status: 'error', error: String(e?.message || e) });
+      }
+    }
+  } catch (e: any) {
+    manifestError = String(e?.message || e);
+    manifestLoading = false;
+  }
+}
+
+export async function getOverlayForSop(args: {
+  sopInstanceUID: string;
+  index: number;
+  instanceNumber: number | null;
+  imagePosition: [number, number, number] | null;
+}): Promise<OverlayResult | null> {
+  if (!primarySeriesId || !secondarySeriesId) return null;
+  const m = getFusionManifest(primarySeriesId);
+  const ready = m?.secondaries.some((s) => s.secondarySeriesId === secondarySeriesId && s.status === 'ready');
+  if (!ready) return null;
+  const { sopInstanceUID, index, instanceNumber, imagePosition } = args;
+  try {
+    let slice;
+    try {
+      slice = await getFusedSlice(primarySeriesId, secondarySeriesId, sopInstanceUID);
+    } catch {
+      slice = await getFusedSliceSmart(primarySeriesId, secondarySeriesId, sopInstanceUID, instanceNumber ?? undefined, index, imagePosition ?? undefined as any);
+    }
+    const overlay = fuseboxSliceToImageData(slice, secondaryModality ?? 'PT');
+    const canvas = document.createElement('canvas');
+    canvas.width = overlay.imageData.width;
+    canvas.height = overlay.imageData.height;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return null;
+    ctx.putImageData(overlay.imageData, 0, 0);
+    return {
+      canvas,
+      hasSignal: overlay.hasSignal,
+      registrationId: slice.registrationId ?? null,
+      transformSource: slice.transformSource ?? null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function getManifest(): FusionManifest | null { return manifest; }
+export function getStatuses() { return secondaryStatuses; }
+export function isManifestLoading() { return manifestLoading; }
+export function getManifestError() { return manifestError; }
+

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@uppy/file-input": "^4.2.2",
     "@uppy/progress-bar": "^4.3.2",
     "@uppy/react": "^4.5.2",
+    "archiver": "^7.0.1",
     "bull": "^4.16.5",
     "canvas": "^3.1.2",
     "class-variance-authority": "^0.7.1",
@@ -121,7 +122,7 @@
     "yauzl": "^3.2.0",
     "zod": "^3.24.2",
     "zod-validation-error": "^3.4.0",
-    "archiver": "^7.0.1"
+    "zustand": "^4.5.5"
   },
   "devDependencies": {
     "@replit/vite-plugin-cartographer": "^0.2.7",


### PR DESCRIPTION
Refactor fusion overlay logic into a dedicated store and unify rendering to decouple concerns from core viewer components and eliminate duplicated code paths.

---
<a href="https://cursor.com/background-agent?bcId=bc-42d19bcc-f90e-4426-9f66-0001b1d488ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-42d19bcc-f90e-4426-9f66-0001b1d488ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

