### PR TITLE
Add WebGPU-accelerated deformable image registration pipeline

### DIFF
--- a/client/src/lib/webgpu/deformable-fusion.ts
+++ b/client/src/lib/webgpu/deformable-fusion.ts
@@ -1,0 +1,260 @@
+/**
+ * Deformable Fusion Integration
+ *
+ * Bridges the WebGPU block-matching pipeline with the existing fusion system.
+ * Provides a high-level API for computing and caching deformable registrations
+ * between pairs of 2D slices (fixed + moving).
+ *
+ * Usage:
+ *   const manager = new DeformableFusionManager();
+ *   const warped = await manager.warpSlice(fixedPixels, movingPixels, width, height);
+ */
+
+import {
+  computeBlockMatchingDisplacement,
+  applyDisplacementField,
+  displacementFieldStats,
+  isWebGPUAvailable,
+  releaseGPUResources,
+  type BlockMatchingParams,
+  type BlockMatchingResult,
+  type DisplacementField,
+} from './webgpu-block-matching';
+
+export interface DeformableWarpResult {
+  /** Warped moving image pixels (same dimensions as input) */
+  warpedPixels: Float32Array;
+  /** Width of the output */
+  width: number;
+  /** Height of the output */
+  height: number;
+  /** Displacement field used for the warp */
+  displacementField: DisplacementField;
+  /** Pipeline timing info */
+  timing: BlockMatchingResult['timing'];
+  /** Displacement statistics */
+  stats: {
+    meanMagnitude: number;
+    maxMagnitude: number;
+    medianMagnitude: number;
+    percentile95: number;
+  };
+}
+
+export interface DeformableFusionConfig {
+  /** Enable/disable deformable registration (default: true if WebGPU available) */
+  enabled?: boolean;
+  /** Block matching parameters */
+  blockMatchingParams?: BlockMatchingParams;
+  /** Maximum cache entries for displacement fields */
+  maxCacheSize?: number;
+  /** Minimum displacement magnitude to apply deformable warp (below this, skip) */
+  minDisplacementThreshold?: number;
+}
+
+const DEFAULT_CONFIG: Required<DeformableFusionConfig> = {
+  enabled: true,
+  blockMatchingParams: {
+    blockSize: 16,
+    searchRadius: 32,
+    alpha: 50.0,
+    refinementIterations: 40,
+  },
+  maxCacheSize: 50,
+  minDisplacementThreshold: 0.5,
+};
+
+/**
+ * Manages deformable registration for fusion overlays.
+ *
+ * Caches displacement fields keyed by slice identity so repeated
+ * requests for the same slice pair don't re-run the GPU pipeline.
+ */
+export class DeformableFusionManager {
+  private config: Required<DeformableFusionConfig>;
+  private cache = new Map<string, { field: DisplacementField; timestamp: number }>();
+  private webgpuAvailable: boolean;
+
+  constructor(config?: DeformableFusionConfig) {
+    this.config = { ...DEFAULT_CONFIG, ...config };
+    if (config?.blockMatchingParams) {
+      this.config.blockMatchingParams = {
+        ...DEFAULT_CONFIG.blockMatchingParams,
+        ...config.blockMatchingParams,
+      };
+    }
+    this.webgpuAvailable = isWebGPUAvailable();
+  }
+
+  /**
+   * Whether deformable registration is available and enabled.
+   */
+  get isAvailable(): boolean {
+    return this.webgpuAvailable && this.config.enabled;
+  }
+
+  /**
+   * Compute deformable registration and warp the moving slice to match the fixed slice.
+   *
+   * @param fixedPixels  - Float32Array of the fixed (primary) slice in row-major order
+   * @param movingPixels - Float32Array of the moving (secondary) slice in row-major order
+   * @param width        - Image width
+   * @param height       - Image height
+   * @param cacheKey     - Optional key for caching (e.g., `${primarySOP}:${secondarySOP}`)
+   * @param params       - Override block matching params for this call
+   */
+  async warpSlice(
+    fixedPixels: Float32Array,
+    movingPixels: Float32Array,
+    width: number,
+    height: number,
+    cacheKey?: string,
+    params?: BlockMatchingParams,
+  ): Promise<DeformableWarpResult> {
+    if (!this.isAvailable) {
+      throw new Error('Deformable registration unavailable: WebGPU not supported or disabled');
+    }
+
+    // Check cache
+    if (cacheKey) {
+      const cached = this.cache.get(cacheKey);
+      if (cached) {
+        const warpedPixels = applyDisplacementField(movingPixels, cached.field);
+        const stats = displacementFieldStats(cached.field);
+        return {
+          warpedPixels,
+          width,
+          height,
+          displacementField: cached.field,
+          timing: { blockMatching: 0, interpolation: 0, refinement: 0, readback: 0, total: 0 },
+          stats,
+        };
+      }
+    }
+
+    // Run GPU pipeline
+    const matchParams = params ?? this.config.blockMatchingParams;
+    const result = await computeBlockMatchingDisplacement(
+      fixedPixels,
+      movingPixels,
+      width,
+      height,
+      matchParams,
+    );
+
+    const stats = displacementFieldStats(result.displacementField);
+
+    // Cache the displacement field
+    if (cacheKey) {
+      this.cache.set(cacheKey, {
+        field: result.displacementField,
+        timestamp: Date.now(),
+      });
+      this.evictCache();
+    }
+
+    // If displacement is negligible, return moving image as-is
+    if (stats.medianMagnitude < this.config.minDisplacementThreshold) {
+      console.log(
+        `[deformable-fusion] Median displacement ${stats.medianMagnitude.toFixed(2)}px below threshold ` +
+        `(${this.config.minDisplacementThreshold}px), skipping warp`,
+      );
+      return {
+        warpedPixels: movingPixels,
+        width,
+        height,
+        displacementField: result.displacementField,
+        timing: result.timing,
+        stats,
+      };
+    }
+
+    // Apply displacement field (CPU — could be moved to GPU warp shader for perf)
+    const warpedPixels = applyDisplacementField(movingPixels, result.displacementField);
+
+    console.log(
+      `[deformable-fusion] Warp complete: ` +
+      `median=${stats.medianMagnitude.toFixed(1)}px, max=${stats.maxMagnitude.toFixed(1)}px, ` +
+      `p95=${stats.percentile95.toFixed(1)}px | ` +
+      `GPU: match=${result.timing.blockMatching.toFixed(0)}ms, ` +
+      `interp=${result.timing.interpolation.toFixed(0)}ms, ` +
+      `refine=${result.timing.refinement.toFixed(0)}ms, ` +
+      `total=${result.timing.total.toFixed(0)}ms`,
+    );
+
+    return {
+      warpedPixels,
+      width,
+      height,
+      displacementField: result.displacementField,
+      timing: result.timing,
+      stats,
+    };
+  }
+
+  /**
+   * Get a cached displacement field (if available) without re-running the pipeline.
+   */
+  getCachedField(cacheKey: string): DisplacementField | null {
+    return this.cache.get(cacheKey)?.field ?? null;
+  }
+
+  /**
+   * Clear all cached displacement fields.
+   */
+  clearCache(): void {
+    this.cache.clear();
+  }
+
+  /**
+   * Update configuration. Clears cache if block matching params change.
+   */
+  updateConfig(config: Partial<DeformableFusionConfig>): void {
+    const paramsChanged = config.blockMatchingParams !== undefined;
+    Object.assign(this.config, config);
+    if (config.blockMatchingParams) {
+      this.config.blockMatchingParams = {
+        ...DEFAULT_CONFIG.blockMatchingParams,
+        ...config.blockMatchingParams,
+      };
+    }
+    if (paramsChanged) {
+      this.clearCache();
+    }
+  }
+
+  /**
+   * Release all GPU and cache resources.
+   */
+  destroy(): void {
+    this.clearCache();
+    releaseGPUResources();
+  }
+
+  private evictCache(): void {
+    if (this.cache.size <= this.config.maxCacheSize) return;
+    // Evict oldest entries
+    const entries = Array.from(this.cache.entries()).sort((a, b) => a[1].timestamp - b[1].timestamp);
+    const toRemove = entries.length - this.config.maxCacheSize;
+    for (let i = 0; i < toRemove; i++) {
+      this.cache.delete(entries[i][0]);
+    }
+  }
+}
+
+/**
+ * Singleton instance for global use within the fusion system.
+ */
+let globalManager: DeformableFusionManager | null = null;
+
+export function getDeformableFusionManager(config?: DeformableFusionConfig): DeformableFusionManager {
+  if (!globalManager) {
+    globalManager = new DeformableFusionManager(config);
+  }
+  return globalManager;
+}
+
+export function destroyDeformableFusionManager(): void {
+  globalManager?.destroy();
+  globalManager = null;
+}

--- a/client/src/lib/webgpu/index.ts
+++ b/client/src/lib/webgpu/index.ts
@@ -1,0 +1,18 @@
+export {
+  computeBlockMatchingDisplacement,
+  applyDisplacementField,
+  displacementFieldStats,
+  isWebGPUAvailable,
+  releaseGPUResources,
+  type BlockMatchingParams,
+  type BlockMatchingResult,
+  type DisplacementField,
+} from './webgpu-block-matching';
+
+export {
+  DeformableFusionManager,
+  getDeformableFusionManager,
+  destroyDeformableFusionManager,
+  type DeformableWarpResult,
+  type DeformableFusionConfig,
+} from './deformable-fusion';

--- a/client/src/lib/webgpu/shaders/block-matching.wgsl
+++ b/client/src/lib/webgpu/shaders/block-matching.wgsl
@@ -1,0 +1,117 @@
+// Pass 1: Coarse Block Matching via Sum of Absolute Differences (SAD)
+//
+// Each workgroup handles one block in the fixed image and searches a
+// (2 * searchRadius + 1)^2 neighborhood in the moving image for the
+// candidate offset that minimizes SAD. The best motion vector (dx, dy)
+// is written to a sparse grid.
+//
+// Dispatch: ceil(imageWidth / blockSize) x ceil(imageHeight / blockSize) x 1
+// Workgroup: blockSize x blockSize x 1  (one thread per pixel in the block)
+
+struct Params {
+  imageWidth:    u32,
+  imageHeight:   u32,
+  blockSize:     u32,
+  searchRadius:  u32,
+  gridWidth:     u32,  // ceil(imageWidth / blockSize)
+  gridHeight:    u32,  // ceil(imageHeight / blockSize)
+};
+
+@group(0) @binding(0) var<uniform> params: Params;
+@group(0) @binding(1) var<storage, read> fixedImage:  array<f32>;
+@group(0) @binding(2) var<storage, read> movingImage: array<f32>;
+@group(0) @binding(3) var<storage, read_write> motionVectors: array<f32>; // 2 floats per block (dx, dy)
+
+// Shared memory: each thread contributes its per-candidate |diff| here.
+// Max workgroup size 16x16 = 256 threads.
+var<workgroup> sadAccum: array<atomic<u32>, 1>;
+var<workgroup> localSAD: array<f32, 256>;
+
+fn sampleFixed(x: i32, y: i32) -> f32 {
+  let cx = clamp(x, 0, i32(params.imageWidth) - 1);
+  let cy = clamp(y, 0, i32(params.imageHeight) - 1);
+  return fixedImage[u32(cy) * params.imageWidth + u32(cx)];
+}
+
+fn sampleMoving(x: i32, y: i32) -> f32 {
+  let cx = clamp(x, 0, i32(params.imageWidth) - 1);
+  let cy = clamp(y, 0, i32(params.imageHeight) - 1);
+  return movingImage[u32(cy) * params.imageWidth + u32(cx)];
+}
+
+@compute @workgroup_size(16, 16, 1)
+fn main(
+  @builtin(workgroup_id)         wgId:    vec3<u32>,
+  @builtin(local_invocation_id)  localId: vec3<u32>,
+  @builtin(local_invocation_index) localIdx: u32,
+) {
+  let blockSize = params.blockSize;
+  let searchRadius = i32(params.searchRadius);
+
+  // Block origin in image coordinates
+  let blockX = i32(wgId.x * blockSize);
+  let blockY = i32(wgId.y * blockSize);
+
+  // This thread's pixel within the block
+  let px = i32(localId.x);
+  let py = i32(localId.y);
+  let inBlock = (u32(px) < blockSize) && (u32(py) < blockSize);
+
+  // Pixel coordinates in the fixed image
+  let fixX = blockX + px;
+  let fixY = blockY + py;
+
+  // Pre-fetch the fixed pixel value for this thread
+  var fixedVal: f32 = 0.0;
+  if (inBlock) {
+    fixedVal = sampleFixed(fixX, fixY);
+  }
+
+  // Exhaustive search over candidate offsets
+  var bestSAD: f32 = 1e20;
+  var bestDx: i32 = 0;
+  var bestDy: i32 = 0;
+
+  // We iterate over all candidate offsets. Each thread computes its own
+  // |fixed - moving| difference and we reduce across the workgroup.
+  // For simplicity and correctness on all GPUs, we use a sequential
+  // reduction pattern where thread 0 accumulates.
+  for (var dy: i32 = -searchRadius; dy <= searchRadius; dy = dy + 1) {
+    for (var dx: i32 = -searchRadius; dx <= searchRadius; dx = dx + 1) {
+      // Each thread computes its pixel's absolute difference
+      var diff: f32 = 0.0;
+      if (inBlock) {
+        let movX = fixX + dx;
+        let movY = fixY + dy;
+        let movingVal = sampleMoving(movX, movY);
+        diff = abs(fixedVal - movingVal);
+      }
+
+      // Store to shared memory
+      localSAD[localIdx] = diff;
+      workgroupBarrier();
+
+      // Thread 0 sums all contributions
+      if (localIdx == 0u) {
+        var totalSAD: f32 = 0.0;
+        let numThreads = blockSize * blockSize;
+        for (var i: u32 = 0u; i < numThreads; i = i + 1u) {
+          totalSAD = totalSAD + localSAD[i];
+        }
+        if (totalSAD < bestSAD) {
+          bestSAD = totalSAD;
+          bestDx = dx;
+          bestDy = dy;
+        }
+      }
+      workgroupBarrier();
+    }
+  }
+
+  // Thread 0 writes the result
+  if (localIdx == 0u) {
+    let gridIdx = wgId.y * params.gridWidth + wgId.x;
+    motionVectors[gridIdx * 2u]      = f32(bestDx);
+    motionVectors[gridIdx * 2u + 1u] = f32(bestDy);
+  }
+}

--- a/client/src/lib/webgpu/shaders/dense-interpolation.wgsl
+++ b/client/src/lib/webgpu/shaders/dense-interpolation.wgsl
@@ -1,0 +1,73 @@
+// Pass 2: Dense Interpolation of Sparse Motion Vectors
+//
+// Takes the sparse block-level motion vectors from Pass 1 and produces
+// a full-resolution displacement field via bilinear interpolation between
+// block centers.
+//
+// Dispatch: ceil(imageWidth / 16) x ceil(imageHeight / 16) x 1
+// Workgroup: 16 x 16 x 1
+
+struct Params {
+  imageWidth:  u32,
+  imageHeight: u32,
+  blockSize:   u32,
+  gridWidth:   u32,  // ceil(imageWidth / blockSize)
+  gridHeight:  u32,  // ceil(imageHeight / blockSize)
+  _pad0:       u32,
+  _pad1:       u32,
+  _pad2:       u32,
+};
+
+@group(0) @binding(0) var<uniform> params: Params;
+@group(0) @binding(1) var<storage, read> motionVectors: array<f32>;       // sparse (dx,dy) per block
+@group(0) @binding(2) var<storage, read_write> displacementField: array<f32>; // dense (dx,dy) per pixel
+
+fn getMotionVector(gx: i32, gy: i32) -> vec2<f32> {
+  let cx = clamp(gx, 0, i32(params.gridWidth) - 1);
+  let cy = clamp(gy, 0, i32(params.gridHeight) - 1);
+  let idx = u32(cy) * params.gridWidth + u32(cx);
+  return vec2<f32>(motionVectors[idx * 2u], motionVectors[idx * 2u + 1u]);
+}
+
+@compute @workgroup_size(16, 16, 1)
+fn main(
+  @builtin(global_invocation_id) gid: vec3<u32>,
+) {
+  let x = gid.x;
+  let y = gid.y;
+  if (x >= params.imageWidth || y >= params.imageHeight) {
+    return;
+  }
+
+  let blockSize = f32(params.blockSize);
+  let halfBlock = blockSize * 0.5;
+
+  // Continuous block-grid coordinate (block centers are at (gx+0.5)*blockSize)
+  let fx = (f32(x) - halfBlock + 0.5) / blockSize;
+  let fy = (f32(y) - halfBlock + 0.5) / blockSize;
+
+  // Integer grid coordinates of the 4 surrounding block centers
+  let gx0 = i32(floor(fx));
+  let gy0 = i32(floor(fy));
+  let gx1 = gx0 + 1;
+  let gy1 = gy0 + 1;
+
+  // Fractional weights
+  let wx = fx - f32(gx0);
+  let wy = fy - f32(gy0);
+
+  // Fetch 4 neighbors
+  let v00 = getMotionVector(gx0, gy0);
+  let v10 = getMotionVector(gx1, gy0);
+  let v01 = getMotionVector(gx0, gy1);
+  let v11 = getMotionVector(gx1, gy1);
+
+  // Bilinear interpolation
+  let top    = mix(v00, v10, wx);
+  let bottom = mix(v01, v11, wx);
+  let result = mix(top, bottom, wy);
+
+  let pixelIdx = y * params.imageWidth + x;
+  displacementField[pixelIdx * 2u]      = result.x;
+  displacementField[pixelIdx * 2u + 1u] = result.y;
+}

--- a/client/src/lib/webgpu/shaders/horn-schunck.wgsl
+++ b/client/src/lib/webgpu/shaders/horn-schunck.wgsl
@@ -1,0 +1,114 @@
+// Pass 3: Horn-Schunck Optical Flow Refinement
+//
+// Iterative Jacobi solver that refines the displacement field from Pass 2
+// using the Horn-Schunck variational model on the residual (after warping
+// the moving image by the coarse displacement field).
+//
+// Each dispatch is ONE iteration. The orchestrator runs N dispatches,
+// ping-ponging between two displacement buffers.
+//
+// The data term uses image gradients computed from the warped moving image
+// and the fixed image. The smoothness term uses the 4-connected Laplacian.
+//
+// Dispatch: ceil(imageWidth / 16) x ceil(imageHeight / 16) x 1
+// Workgroup: 16 x 16 x 1
+
+struct Params {
+  imageWidth:  u32,
+  imageHeight: u32,
+  alpha:       f32,   // smoothness weight (higher = smoother field)
+  _pad0:       u32,
+};
+
+@group(0) @binding(0) var<uniform> params: Params;
+@group(0) @binding(1) var<storage, read> fixedImage:  array<f32>;
+@group(0) @binding(2) var<storage, read> movingImage: array<f32>;
+@group(0) @binding(3) var<storage, read> fieldIn:     array<f32>;  // current displacement (dx,dy) per pixel
+@group(0) @binding(4) var<storage, read_write> fieldOut: array<f32>; // updated displacement
+
+fn pixelIdx(x: u32, y: u32) -> u32 {
+  return y * params.imageWidth + x;
+}
+
+fn sampleFixed(x: i32, y: i32) -> f32 {
+  let cx = clamp(x, 0, i32(params.imageWidth) - 1);
+  let cy = clamp(y, 0, i32(params.imageHeight) - 1);
+  return fixedImage[u32(cy) * params.imageWidth + u32(cx)];
+}
+
+fn sampleMoving(x: i32, y: i32) -> f32 {
+  let cx = clamp(x, 0, i32(params.imageWidth) - 1);
+  let cy = clamp(y, 0, i32(params.imageHeight) - 1);
+  return movingImage[u32(cy) * params.imageWidth + u32(cx)];
+}
+
+// Bilinear sample of moving image at continuous coordinates
+fn sampleMovingBilinear(fx: f32, fy: f32) -> f32 {
+  let x0 = i32(floor(fx));
+  let y0 = i32(floor(fy));
+  let x1 = x0 + 1;
+  let y1 = y0 + 1;
+  let wx = fx - f32(x0);
+  let wy = fy - f32(y0);
+
+  let v00 = sampleMoving(x0, y0);
+  let v10 = sampleMoving(x1, y0);
+  let v01 = sampleMoving(x0, y1);
+  let v11 = sampleMoving(x1, y1);
+
+  return mix(mix(v00, v10, wx), mix(v01, v11, wx), wy);
+}
+
+fn getField(x: i32, y: i32) -> vec2<f32> {
+  let cx = u32(clamp(x, 0, i32(params.imageWidth) - 1));
+  let cy = u32(clamp(y, 0, i32(params.imageHeight) - 1));
+  let idx = cy * params.imageWidth + cx;
+  return vec2<f32>(fieldIn[idx * 2u], fieldIn[idx * 2u + 1u]);
+}
+
+@compute @workgroup_size(16, 16, 1)
+fn main(
+  @builtin(global_invocation_id) gid: vec3<u32>,
+) {
+  let x = gid.x;
+  let y = gid.y;
+  if (x >= params.imageWidth || y >= params.imageHeight) {
+    return;
+  }
+
+  let ix = i32(x);
+  let iy = i32(y);
+  let alpha2 = params.alpha * params.alpha;
+
+  // Current displacement at this pixel
+  let uv = getField(ix, iy);
+
+  // 4-connected Laplacian (average of neighbors)
+  let uL = getField(ix - 1, iy);
+  let uR = getField(ix + 1, iy);
+  let uU = getField(ix, iy - 1);
+  let uD = getField(ix, iy + 1);
+  let uvAvg = (uL + uR + uU + uD) * 0.25;
+
+  // Warped position in moving image
+  let warpX = f32(x) + uv.x;
+  let warpY = f32(y) + uv.y;
+
+  // Image gradients at warped position (central differences on moving image)
+  let Ix = (sampleMovingBilinear(warpX + 1.0, warpY) - sampleMovingBilinear(warpX - 1.0, warpY)) * 0.5;
+  let Iy = (sampleMovingBilinear(warpX, warpY + 1.0) - sampleMovingBilinear(warpX, warpY - 1.0)) * 0.5;
+
+  // Temporal gradient: difference between warped moving and fixed
+  let It = sampleMovingBilinear(warpX, warpY) - sampleFixed(ix, iy);
+
+  // Horn-Schunck update (Jacobi iteration)
+  let denom = alpha2 + Ix * Ix + Iy * Iy;
+  let crossTerm = Ix * uvAvg.x + Iy * uvAvg.y + It;
+
+  let newU = uvAvg.x - Ix * crossTerm / denom;
+  let newV = uvAvg.y - Iy * crossTerm / denom;
+
+  let idx = y * params.imageWidth + x;
+  fieldOut[idx * 2u]      = newU;
+  fieldOut[idx * 2u + 1u] = newV;
+}

--- a/client/src/lib/webgpu/shaders/warp-image.wgsl
+++ b/client/src/lib/webgpu/shaders/warp-image.wgsl
@@ -1,0 +1,60 @@
+// Apply displacement field to warp an image on GPU via bilinear interpolation.
+//
+// Dispatch: ceil(imageWidth / 16) x ceil(imageHeight / 16) x 1
+// Workgroup: 16 x 16 x 1
+
+struct Params {
+  imageWidth:  u32,
+  imageHeight: u32,
+  _pad0:       u32,
+  _pad1:       u32,
+};
+
+@group(0) @binding(0) var<uniform> params: Params;
+@group(0) @binding(1) var<storage, read> sourceImage: array<f32>;
+@group(0) @binding(2) var<storage, read> displacementField: array<f32>; // interleaved (dx, dy) per pixel
+@group(0) @binding(3) var<storage, read_write> outputImage: array<f32>;
+
+fn sampleBilinear(fx: f32, fy: f32) -> f32 {
+  let w = i32(params.imageWidth);
+  let h = i32(params.imageHeight);
+  let x0 = i32(floor(fx));
+  let y0 = i32(floor(fy));
+  let x1 = x0 + 1;
+  let y1 = y0 + 1;
+
+  let cx0 = clamp(x0, 0, w - 1);
+  let cx1 = clamp(x1, 0, w - 1);
+  let cy0 = clamp(y0, 0, h - 1);
+  let cy1 = clamp(y1, 0, h - 1);
+
+  let wx = fx - f32(x0);
+  let wy = fy - f32(y0);
+
+  let v00 = sourceImage[u32(cy0) * params.imageWidth + u32(cx0)];
+  let v10 = sourceImage[u32(cy0) * params.imageWidth + u32(cx1)];
+  let v01 = sourceImage[u32(cy1) * params.imageWidth + u32(cx0)];
+  let v11 = sourceImage[u32(cy1) * params.imageWidth + u32(cx1)];
+
+  return mix(mix(v00, v10, wx), mix(v01, v11, wx), wy);
+}
+
+@compute @workgroup_size(16, 16, 1)
+fn main(
+  @builtin(global_invocation_id) gid: vec3<u32>,
+) {
+  let x = gid.x;
+  let y = gid.y;
+  if (x >= params.imageWidth || y >= params.imageHeight) {
+    return;
+  }
+
+  let idx = y * params.imageWidth + x;
+  let dx = displacementField[idx * 2u];
+  let dy = displacementField[idx * 2u + 1u];
+
+  let srcX = f32(x) + dx;
+  let srcY = f32(y) + dy;
+
+  outputImage[idx] = sampleBilinear(srcX, srcY);
+}

--- a/client/src/lib/webgpu/webgpu-block-matching.ts
+++ b/client/src/lib/webgpu/webgpu-block-matching.ts
@@ -1,0 +1,554 @@
+/**
+ * WebGPU Block Matching + Dense Refinement Pipeline
+ *
+ * Three-pass deformable registration inspired by video codec motion estimation:
+ *   Pass 1 — Coarse block matching (SAD) to find large displacements
+ *   Pass 2 — Bilinear interpolation to dense displacement field
+ *   Pass 3 — Horn-Schunck iterative refinement for sub-pixel accuracy
+ *
+ * All computation runs on the GPU via WebGPU compute shaders.
+ */
+
+import blockMatchingWGSL from './shaders/block-matching.wgsl?raw';
+import denseInterpolationWGSL from './shaders/dense-interpolation.wgsl?raw';
+import hornSchunckWGSL from './shaders/horn-schunck.wgsl?raw';
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+export interface BlockMatchingParams {
+  /** Block size in pixels for the matching phase (default: 16) */
+  blockSize?: number;
+  /** Search radius in pixels around each block (default: 32) */
+  searchRadius?: number;
+  /** Horn-Schunck smoothness weight — higher = smoother field (default: 50) */
+  alpha?: number;
+  /** Number of Horn-Schunck refinement iterations (default: 40) */
+  refinementIterations?: number;
+}
+
+export interface DisplacementField {
+  /** Dense displacement vectors, interleaved [dx0, dy0, dx1, dy1, ...] */
+  data: Float32Array;
+  width: number;
+  height: number;
+}
+
+export interface BlockMatchingResult {
+  /** The dense displacement field (dx, dy per pixel) */
+  displacementField: DisplacementField;
+  /** Timing info for each pass in milliseconds */
+  timing: {
+    blockMatching: number;
+    interpolation: number;
+    refinement: number;
+    total: number;
+    readback: number;
+  };
+  /** Sparse motion vectors from Pass 1 (for diagnostics) */
+  sparseVectors: Float32Array;
+  sparseGridWidth: number;
+  sparseGridHeight: number;
+}
+
+// ── GPU Resource Management ────────────────────────────────────────────
+
+interface GPUResources {
+  device: GPUDevice;
+
+  // Pipelines
+  blockMatchPipeline: GPUComputePipeline;
+  interpolationPipeline: GPUComputePipeline;
+  hornSchunckPipeline: GPUComputePipeline;
+
+  // Bind group layouts
+  blockMatchLayout: GPUBindGroupLayout;
+  interpolationLayout: GPUBindGroupLayout;
+  hornSchunckLayout: GPUBindGroupLayout;
+}
+
+let gpuResources: GPUResources | null = null;
+
+async function initGPU(): Promise<GPUResources> {
+  if (gpuResources) return gpuResources;
+
+  if (!navigator.gpu) {
+    throw new Error('WebGPU not supported in this browser');
+  }
+
+  const adapter = await navigator.gpu.requestAdapter({
+    powerPreference: 'high-performance',
+  });
+  if (!adapter) {
+    throw new Error('No WebGPU adapter available');
+  }
+
+  const device = await adapter.requestDevice({
+    requiredLimits: {
+      maxStorageBufferBindingSize: adapter.limits.maxStorageBufferBindingSize,
+      maxBufferSize: adapter.limits.maxBufferSize,
+      maxComputeWorkgroupsPerDimension: adapter.limits.maxComputeWorkgroupsPerDimension,
+    },
+  });
+
+  device.lost.then((info) => {
+    console.error('WebGPU device lost:', info.message);
+    gpuResources = null;
+  });
+
+  // ── Pass 1: Block Matching ──
+
+  const blockMatchModule = device.createShaderModule({
+    label: 'block-matching',
+    code: blockMatchingWGSL,
+  });
+
+  const blockMatchLayout = device.createBindGroupLayout({
+    label: 'block-match-layout',
+    entries: [
+      { binding: 0, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'uniform' } },
+      { binding: 1, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'read-only-storage' } },
+      { binding: 2, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'read-only-storage' } },
+      { binding: 3, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } },
+    ],
+  });
+
+  const blockMatchPipeline = device.createComputePipeline({
+    label: 'block-match-pipeline',
+    layout: device.createPipelineLayout({ bindGroupLayouts: [blockMatchLayout] }),
+    compute: { module: blockMatchModule, entryPoint: 'main' },
+  });
+
+  // ── Pass 2: Dense Interpolation ──
+
+  const interpolationModule = device.createShaderModule({
+    label: 'dense-interpolation',
+    code: denseInterpolationWGSL,
+  });
+
+  const interpolationLayout = device.createBindGroupLayout({
+    label: 'interpolation-layout',
+    entries: [
+      { binding: 0, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'uniform' } },
+      { binding: 1, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'read-only-storage' } },
+      { binding: 2, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } },
+    ],
+  });
+
+  const interpolationPipeline = device.createComputePipeline({
+    label: 'interpolation-pipeline',
+    layout: device.createPipelineLayout({ bindGroupLayouts: [interpolationLayout] }),
+    compute: { module: interpolationModule, entryPoint: 'main' },
+  });
+
+  // ── Pass 3: Horn-Schunck ──
+
+  const hornSchunckModule = device.createShaderModule({
+    label: 'horn-schunck',
+    code: hornSchunckWGSL,
+  });
+
+  const hornSchunckLayout = device.createBindGroupLayout({
+    label: 'horn-schunck-layout',
+    entries: [
+      { binding: 0, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'uniform' } },
+      { binding: 1, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'read-only-storage' } },
+      { binding: 2, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'read-only-storage' } },
+      { binding: 3, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'read-only-storage' } },
+      { binding: 4, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } },
+    ],
+  });
+
+  const hornSchunckPipeline = device.createComputePipeline({
+    label: 'horn-schunck-pipeline',
+    layout: device.createPipelineLayout({ bindGroupLayouts: [hornSchunckLayout] }),
+    compute: { module: hornSchunckModule, entryPoint: 'main' },
+  });
+
+  gpuResources = {
+    device,
+    blockMatchPipeline,
+    interpolationPipeline,
+    hornSchunckPipeline,
+    blockMatchLayout,
+    interpolationLayout,
+    hornSchunckLayout,
+  };
+
+  return gpuResources;
+}
+
+// ── Utility ────────────────────────────────────────────────────────────
+
+function createBufferFromData(device: GPUDevice, data: ArrayBuffer, usage: GPUBufferUsageFlags, label: string): GPUBuffer {
+  const buffer = device.createBuffer({
+    label,
+    size: Math.max(data.byteLength, 4), // WebGPU requires size > 0
+    usage,
+    mappedAtCreation: true,
+  });
+  new Uint8Array(buffer.getMappedRange()).set(new Uint8Array(data));
+  buffer.unmap();
+  return buffer;
+}
+
+function createEmptyBuffer(device: GPUDevice, byteSize: number, usage: GPUBufferUsageFlags, label: string): GPUBuffer {
+  return device.createBuffer({
+    label,
+    size: Math.max(byteSize, 4),
+    usage,
+  });
+}
+
+/** Normalize a Float32Array to [0, 1] for better SAD matching */
+function normalizeImage(data: Float32Array): Float32Array {
+  let min = Infinity;
+  let max = -Infinity;
+  for (let i = 0; i < data.length; i++) {
+    const v = data[i];
+    if (v < min) min = v;
+    if (v > max) max = v;
+  }
+  const range = max - min || 1;
+  const out = new Float32Array(data.length);
+  for (let i = 0; i < data.length; i++) {
+    out[i] = (data[i] - min) / range;
+  }
+  return out;
+}
+
+// ── Main Pipeline ──────────────────────────────────────────────────────
+
+/**
+ * Run the full block-matching + dense refinement pipeline on two 2D images.
+ *
+ * Both images must be the same dimensions. Pixel data is flat Float32Array
+ * in row-major order.
+ */
+export async function computeBlockMatchingDisplacement(
+  fixedImageData: Float32Array,
+  movingImageData: Float32Array,
+  imageWidth: number,
+  imageHeight: number,
+  params?: BlockMatchingParams,
+): Promise<BlockMatchingResult> {
+  const blockSize = params?.blockSize ?? 16;
+  const searchRadius = params?.searchRadius ?? 32;
+  const alpha = params?.alpha ?? 50.0;
+  const refinementIterations = params?.refinementIterations ?? 40;
+
+  const gridWidth = Math.ceil(imageWidth / blockSize);
+  const gridHeight = Math.ceil(imageHeight / blockSize);
+  const numPixels = imageWidth * imageHeight;
+
+  // Normalize images to [0,1] for consistent SAD values
+  const fixedNorm = normalizeImage(fixedImageData);
+  const movingNorm = normalizeImage(movingImageData);
+
+  const gpu = await initGPU();
+  const { device } = gpu;
+
+  const t0 = performance.now();
+
+  // ── Upload images ──
+
+  const fixedBuf = createBufferFromData(
+    device, fixedNorm.buffer, GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC, 'fixed-image',
+  );
+  const movingBuf = createBufferFromData(
+    device, movingNorm.buffer, GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC, 'moving-image',
+  );
+
+  // ── Pass 1: Block Matching ──
+
+  const pass1ParamsData = new Uint32Array([
+    imageWidth, imageHeight, blockSize, searchRadius, gridWidth, gridHeight,
+  ]);
+  const pass1ParamsBuf = createBufferFromData(
+    device, pass1ParamsData.buffer, GPUBufferUsage.UNIFORM, 'block-match-params',
+  );
+
+  const sparseVectorBytes = gridWidth * gridHeight * 2 * 4; // 2 floats per block
+  const sparseVectorBuf = createEmptyBuffer(
+    device, sparseVectorBytes, GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC, 'sparse-vectors',
+  );
+
+  const pass1BindGroup = device.createBindGroup({
+    layout: gpu.blockMatchLayout,
+    entries: [
+      { binding: 0, resource: { buffer: pass1ParamsBuf } },
+      { binding: 1, resource: { buffer: fixedBuf } },
+      { binding: 2, resource: { buffer: movingBuf } },
+      { binding: 3, resource: { buffer: sparseVectorBuf } },
+    ],
+  });
+
+  const t1 = performance.now();
+
+  const encoder1 = device.createCommandEncoder({ label: 'block-match-encoder' });
+  const pass1 = encoder1.beginComputePass({ label: 'block-match-pass' });
+  pass1.setPipeline(gpu.blockMatchPipeline);
+  pass1.setBindGroup(0, pass1BindGroup);
+  pass1.dispatchWorkgroups(gridWidth, gridHeight, 1);
+  pass1.end();
+  device.queue.submit([encoder1.finish()]);
+  await device.queue.onSubmittedWorkDone();
+
+  const t2 = performance.now();
+
+  // ── Pass 2: Dense Interpolation ──
+
+  // Params struct has 8 u32 fields (padded to 32 bytes)
+  const pass2ParamsData = new Uint32Array([
+    imageWidth, imageHeight, blockSize, gridWidth, gridHeight, 0, 0, 0,
+  ]);
+  const pass2ParamsBuf = createBufferFromData(
+    device, pass2ParamsData.buffer, GPUBufferUsage.UNIFORM, 'interpolation-params',
+  );
+
+  const denseFieldBytes = numPixels * 2 * 4; // 2 floats per pixel
+  const denseFieldBufA = createEmptyBuffer(
+    device, denseFieldBytes, GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC, 'dense-field-A',
+  );
+
+  const pass2BindGroup = device.createBindGroup({
+    layout: gpu.interpolationLayout,
+    entries: [
+      { binding: 0, resource: { buffer: pass2ParamsBuf } },
+      { binding: 1, resource: { buffer: sparseVectorBuf } },
+      { binding: 2, resource: { buffer: denseFieldBufA } },
+    ],
+  });
+
+  const encoder2 = device.createCommandEncoder({ label: 'interpolation-encoder' });
+  const pass2 = encoder2.beginComputePass({ label: 'interpolation-pass' });
+  pass2.setPipeline(gpu.interpolationPipeline);
+  pass2.setBindGroup(0, pass2BindGroup);
+  pass2.dispatchWorkgroups(
+    Math.ceil(imageWidth / 16),
+    Math.ceil(imageHeight / 16),
+    1,
+  );
+  pass2.end();
+  device.queue.submit([encoder2.finish()]);
+  await device.queue.onSubmittedWorkDone();
+
+  const t3 = performance.now();
+
+  // ── Pass 3: Horn-Schunck Refinement (ping-pong) ──
+
+  // Use a Float32Array for the mixed uniform buffer (u32, u32, f32, u32)
+  const pass3ParamsF32 = new Float32Array(4);
+  const pass3ParamsU32 = new Uint32Array(pass3ParamsF32.buffer);
+  pass3ParamsU32[0] = imageWidth;
+  pass3ParamsU32[1] = imageHeight;
+  pass3ParamsF32[2] = alpha;
+  pass3ParamsU32[3] = 0; // padding
+
+  const pass3ParamsBuf = createBufferFromData(
+    device, pass3ParamsF32.buffer, GPUBufferUsage.UNIFORM, 'horn-schunck-params',
+  );
+
+  // Second displacement buffer for ping-pong
+  const denseFieldBufB = createEmptyBuffer(
+    device, denseFieldBytes, GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC, 'dense-field-B',
+  );
+
+  const hsWorkgroupsX = Math.ceil(imageWidth / 16);
+  const hsWorkgroupsY = Math.ceil(imageHeight / 16);
+
+  // Create both bind groups for ping-pong
+  const hsBindGroupAtoB = device.createBindGroup({
+    layout: gpu.hornSchunckLayout,
+    entries: [
+      { binding: 0, resource: { buffer: pass3ParamsBuf } },
+      { binding: 1, resource: { buffer: fixedBuf } },
+      { binding: 2, resource: { buffer: movingBuf } },
+      { binding: 3, resource: { buffer: denseFieldBufA } },  // read from A
+      { binding: 4, resource: { buffer: denseFieldBufB } },  // write to B
+    ],
+  });
+
+  const hsBindGroupBtoA = device.createBindGroup({
+    layout: gpu.hornSchunckLayout,
+    entries: [
+      { binding: 0, resource: { buffer: pass3ParamsBuf } },
+      { binding: 1, resource: { buffer: fixedBuf } },
+      { binding: 2, resource: { buffer: movingBuf } },
+      { binding: 3, resource: { buffer: denseFieldBufB } },  // read from B
+      { binding: 4, resource: { buffer: denseFieldBufA } },  // write to A
+    ],
+  });
+
+  // Run iterations — batch multiple iterations per command encoder for throughput
+  const batchSize = 10;
+  for (let start = 0; start < refinementIterations; start += batchSize) {
+    const end = Math.min(start + batchSize, refinementIterations);
+    const encoder3 = device.createCommandEncoder({ label: `horn-schunck-batch-${start}` });
+    for (let i = start; i < end; i++) {
+      const pass3 = encoder3.beginComputePass({ label: `horn-schunck-iter-${i}` });
+      pass3.setPipeline(gpu.hornSchunckPipeline);
+      pass3.setBindGroup(0, (i % 2 === 0) ? hsBindGroupAtoB : hsBindGroupBtoA);
+      pass3.dispatchWorkgroups(hsWorkgroupsX, hsWorkgroupsY, 1);
+      pass3.end();
+    }
+    device.queue.submit([encoder3.finish()]);
+  }
+  await device.queue.onSubmittedWorkDone();
+
+  const t4 = performance.now();
+
+  // ── Read back results ──
+
+  // Determine which buffer has the final result
+  const finalFieldBuf = (refinementIterations % 2 === 0) ? denseFieldBufA : denseFieldBufB;
+
+  // Dense field readback
+  const readbackBuf = createEmptyBuffer(
+    device, denseFieldBytes, GPUBufferUsage.MAP_READ | GPUBufferUsage.COPY_DST, 'dense-field-readback',
+  );
+  const sparseReadbackBuf = createEmptyBuffer(
+    device, sparseVectorBytes, GPUBufferUsage.MAP_READ | GPUBufferUsage.COPY_DST, 'sparse-readback',
+  );
+
+  const readEncoder = device.createCommandEncoder({ label: 'readback-encoder' });
+  readEncoder.copyBufferToBuffer(finalFieldBuf, 0, readbackBuf, 0, denseFieldBytes);
+  readEncoder.copyBufferToBuffer(sparseVectorBuf, 0, sparseReadbackBuf, 0, sparseVectorBytes);
+  device.queue.submit([readEncoder.finish()]);
+
+  await readbackBuf.mapAsync(GPUMapMode.READ);
+  const denseResult = new Float32Array(readbackBuf.getMappedRange().slice(0));
+  readbackBuf.unmap();
+
+  await sparseReadbackBuf.mapAsync(GPUMapMode.READ);
+  const sparseResult = new Float32Array(sparseReadbackBuf.getMappedRange().slice(0));
+  sparseReadbackBuf.unmap();
+
+  const t5 = performance.now();
+
+  // ── Cleanup GPU buffers ──
+
+  fixedBuf.destroy();
+  movingBuf.destroy();
+  pass1ParamsBuf.destroy();
+  sparseVectorBuf.destroy();
+  pass2ParamsBuf.destroy();
+  denseFieldBufA.destroy();
+  denseFieldBufB.destroy();
+  pass3ParamsBuf.destroy();
+  readbackBuf.destroy();
+  sparseReadbackBuf.destroy();
+
+  return {
+    displacementField: {
+      data: denseResult,
+      width: imageWidth,
+      height: imageHeight,
+    },
+    timing: {
+      blockMatching: t2 - t1,
+      interpolation: t3 - t2,
+      refinement: t4 - t3,
+      readback: t5 - t4,
+      total: t5 - t0,
+    },
+    sparseVectors: sparseResult,
+    sparseGridWidth: gridWidth,
+    sparseGridHeight: gridHeight,
+  };
+}
+
+/**
+ * Apply a displacement field to warp an image (CPU fallback for display).
+ * Uses bilinear interpolation.
+ */
+export function applyDisplacementField(
+  sourceImage: Float32Array,
+  field: DisplacementField,
+): Float32Array {
+  const { width, height, data: fieldData } = field;
+  const output = new Float32Array(width * height);
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const idx = y * width + x;
+      const dx = fieldData[idx * 2];
+      const dy = fieldData[idx * 2 + 1];
+
+      // Source position in moving image
+      const sx = x + dx;
+      const sy = y + dy;
+
+      // Bilinear interpolation
+      const x0 = Math.floor(sx);
+      const y0 = Math.floor(sy);
+      const x1 = x0 + 1;
+      const y1 = y0 + 1;
+      const wx = sx - x0;
+      const wy = sy - y0;
+
+      const cx0 = Math.max(0, Math.min(width - 1, x0));
+      const cx1 = Math.max(0, Math.min(width - 1, x1));
+      const cy0 = Math.max(0, Math.min(height - 1, y0));
+      const cy1 = Math.max(0, Math.min(height - 1, y1));
+
+      const v00 = sourceImage[cy0 * width + cx0];
+      const v10 = sourceImage[cy0 * width + cx1];
+      const v01 = sourceImage[cy1 * width + cx0];
+      const v11 = sourceImage[cy1 * width + cx1];
+
+      output[idx] =
+        v00 * (1 - wx) * (1 - wy) +
+        v10 * wx * (1 - wy) +
+        v01 * (1 - wx) * wy +
+        v11 * wx * wy;
+    }
+  }
+
+  return output;
+}
+
+/**
+ * Compute displacement field magnitude statistics for diagnostics.
+ */
+export function displacementFieldStats(field: DisplacementField): {
+  meanMagnitude: number;
+  maxMagnitude: number;
+  medianMagnitude: number;
+  percentile95: number;
+} {
+  const { data, width, height } = field;
+  const magnitudes: number[] = [];
+
+  for (let i = 0; i < width * height; i++) {
+    const dx = data[i * 2];
+    const dy = data[i * 2 + 1];
+    magnitudes.push(Math.sqrt(dx * dx + dy * dy));
+  }
+
+  magnitudes.sort((a, b) => a - b);
+  const n = magnitudes.length;
+
+  return {
+    meanMagnitude: magnitudes.reduce((s, v) => s + v, 0) / n,
+    maxMagnitude: magnitudes[n - 1],
+    medianMagnitude: magnitudes[Math.floor(n / 2)],
+    percentile95: magnitudes[Math.floor(n * 0.95)],
+  };
+}
+
+/**
+ * Check if WebGPU is available in the current browser.
+ */
+export function isWebGPUAvailable(): boolean {
+  return typeof navigator !== 'undefined' && !!navigator.gpu;
+}
+
+/**
+ * Release cached GPU resources. Call when the module is no longer needed.
+ */
+export function releaseGPUResources(): void {
+  if (gpuResources) {
+    gpuResources.device.destroy();
+    gpuResources = null;
+  }
+}

--- a/client/src/types/shims.d.ts
+++ b/client/src/types/shims.d.ts
@@ -2,3 +2,9 @@ declare module 'yauzl';
 declare module 'fluent-ffmpeg';
 declare module 'archiver';
 
+// Vite raw imports for WebGPU shaders
+declare module '*.wgsl?raw' {
+  const content: string;
+  export default content;
+}
+


### PR DESCRIPTION
## Summary

Introduces a complete WebGPU-based deformable registration system for medical image fusion. This enables GPU-accelerated computation of dense displacement fields between 2D image slices using a three-pass pipeline: coarse block matching, dense interpolation, and iterative Horn-Schunck refinement.

## Key Changes

- **WebGPU Block Matching Pipeline** (`webgpu-block-matching.ts`)
  - Pass 1: Coarse block matching using Sum of Absolute Differences (SAD) to find large displacements
  - Pass 2: Bilinear interpolation to densify sparse motion vectors into full-resolution displacement fields
  - Pass 3: Horn-Schunck optical flow refinement for sub-pixel accuracy via iterative Jacobi solver
  - Configurable parameters: block size, search radius, smoothness weight (alpha), refinement iterations
  - Automatic image normalization for consistent SAD matching

- **Deformable Fusion Manager** (`deformable-fusion.ts`)
  - High-level API wrapping the GPU pipeline with caching and convenience methods
  - LRU cache for displacement fields keyed by slice identity (e.g., SOP instance UID pairs)
  - Displacement magnitude thresholding to skip warping when motion is negligible
  - Comprehensive timing and statistics reporting
  - Singleton pattern for global access within the fusion system

- **WebGPU Compute Shaders** (4 new `.wgsl` files)
  - `block-matching.wgsl`: Exhaustive SAD search with workgroup-level reduction
  - `dense-interpolation.wgsl`: Bilinear interpolation of sparse vectors to dense field
  - `horn-schunck.wgsl`: Iterative refinement using image gradients and Laplacian smoothness
  - `warp-image.wgsl`: GPU-based image warping via displacement field (prepared for future use)

- **Module Exports** (`index.ts`)
  - Centralized export of all WebGPU and deformable fusion APIs

- **TypeScript Shims** (`shims.d.ts`)
  - Added type declarations for Vite raw shader imports (`.wgsl?raw`)

## Implementation Details

- **GPU Resource Management**: Lazy initialization with device loss handling; explicit cleanup via `releaseGPUResources()`
- **Ping-Pong Buffering**: Horn-Schunck refinement alternates between two displacement buffers to avoid read-after-write hazards
- **Batch Submission**: Multiple refinement iterations batched per command encoder for improved throughput
- **Fallback CPU Warping**: `applyDisplacementField()` provides CPU-based bilinear interpolation for display when GPU warping is unavailable
- **Diagnostics**: Displacement field statistics (mean, max, median, 95th percentile magnitudes) for validation and tuning
- **Graceful Degradation**: System checks `isWebGPUAvailable()` and can be disabled via config if needed

## Usage Example

```typescript
const manager = getDeformableFusionManager();
const result = await manager.warpSlice(
  fixedPixels, movingPixels, width, height,
  `${primarySOP}:${secondarySOP}` // cache key
);
console.log(`Median displacement: ${result.stats.medianMagnitude}px`);
```

https://claude.ai/code/session_01GGFKPUbLuPAHokWCse9zWr

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new GPU compute shaders and WebGPU resource management, which can impact performance/stability and browser compatibility. Core logic is additive but introduces non-trivial runtime paths (GPU dispatch/readback, caching, and warp application).
> 
> **Overview**
> Adds a new WebGPU-based deformable 2D slice registration pipeline (`computeBlockMatchingDisplacement`) that computes a dense displacement field via three compute passes (coarse block matching, dense interpolation, Horn–Schunck refinement), plus CPU utilities to apply the field and report displacement stats.
> 
> Introduces `DeformableFusionManager` as a higher-level wrapper for fusion overlays, including slice-pair caching with eviction, configurable thresholds to skip negligible warps, and lifecycle helpers (`getDeformableFusionManager`/`destroyDeformableFusionManager`) with GPU resource cleanup. Exposes the new APIs via `client/src/lib/webgpu/index.ts` and adds a `*.wgsl?raw` TypeScript shim for Vite shader imports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3592e4314d2bf30c075b36d75a63a7a8755c86f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->